### PR TITLE
Intercept instantiate failure and optimizations.

### DIFF
--- a/src/main/java/com/oracle/nosql/spring/data/core/NosqlTemplate.java
+++ b/src/main/java/com/oracle/nosql/spring/data/core/NosqlTemplate.java
@@ -806,16 +806,17 @@ public class NosqlTemplate implements NosqlOperations, ApplicationContextAware {
         Class<T> targetType,
         NosqlQuery query) {
 
+        Class entityType = entityInformation.getJavaType();
+        Class<?> typeToRead = targetType.isInterface() ||
+            targetType.isAssignableFrom(entityType)
+            ? entityType
+            : targetType;
+
         Iterable<MapValue> results = executeMapValueQuery(entityInformation,
             query);
 
         Stream<T> resStream = IterableUtil.getStreamFromIterable(results)
             .map(d -> {
-                Class entityType = entityInformation.getJavaType();
-                Class<?> typeToRead = targetType.isInterface() ||
-                    targetType.isAssignableFrom(entityType)
-                    ? entityType
-                    : targetType;
                 Object source = getConverter().read(typeToRead, d);
                 T result = targetType.isInterface()
                     ? projectionFactory.createProjection(targetType, source)
@@ -865,12 +866,7 @@ public class NosqlTemplate implements NosqlOperations, ApplicationContextAware {
 
         log.debug("Q: {}", sql);
 //        System.out.println("Q: " + sql);
-        Iterable<MapValue> results = doQuery(qReq);
-
-        Stream<MapValue> resStream =
-            IterableUtil.getStreamFromIterable(results);
-
-        return IterableUtil.getIterableFromStream(resStream);
+        return doQuery(qReq);
     }
 
     private PreparedStatement getPreparedStatement(

--- a/src/main/java/com/oracle/nosql/spring/data/core/convert/MappingNosqlConverter.java
+++ b/src/main/java/com/oracle/nosql/spring/data/core/convert/MappingNosqlConverter.java
@@ -734,7 +734,12 @@ public class MappingNosqlConverter
                     return convertFieldValueToObject( value, prop);
                 }
             };
-        return instantiator.createInstance(entity, paramProvider);
+        try {
+            return instantiator.createInstance(entity, paramProvider);
+        } catch (RuntimeException e) {
+            throw new RuntimeException("Failed to instantiate entity type: " +
+                entity.getType() + ". Check available public constructors.", e);
+        }
     }
 
     private <E> void setPojoProperties(NosqlPersistentEntity<E> entity,

--- a/src/main/java/com/oracle/nosql/spring/data/core/query/CriteriaQuery.java
+++ b/src/main/java/com/oracle/nosql/spring/data/core/query/CriteriaQuery.java
@@ -458,7 +458,7 @@ public class CriteriaQuery extends NosqlQuery {
             return "*";
         }
 
-        List<String> inputProperties = returnedType.getInputProperties();
+        List<String> inputProperties = new ArrayList<>();
 
         final NosqlPersistentEntity<?> entity = (NosqlPersistentEntity<?>)
             mappingContext.getPersistentEntity(returnedType.getReturnedType());


### PR DESCRIPTION
Fix generation of projecting queries to avoid selecting the same property twice.
Optimize types outside of loop in find queries.
Avoid creating extra stream when executing queries.