### PR TITLE
Prepare for 1.5.0 release.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,15 @@ All notable changes to this project will be documented in this file.
 
 The format is based on [Keep a Changelog](http://keepachangelog.com/).
 
+## [1.5.0]
+### Added
+- Added support for java.util.Map and similar types as mapping types.
+- Added support for evaluating SpEl expressions on NosqlTable.tableName annotation.
+- Added support for table level default TTL.
+
+### Changed
+- Updated documentation links.
+
 ## [1.4.1]
 ### Added
 - Add a way to return the library version using NosqlDbFactory.getLibraryVersion().

--- a/pom.xml
+++ b/pom.xml
@@ -6,7 +6,7 @@
 
     <groupId>com.oracle.nosql.sdk</groupId>
     <artifactId>spring-data-oracle-nosql</artifactId>
-    <version>1.4.1</version>
+    <version>1.5.0</version>
 
     <name>Oracle NoSQL Database SDK for Spring Data</name>
     <description>Oracle NoSQL Database SDK for Spring Data</description>
@@ -45,7 +45,7 @@
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
         <maven.build.timestamp.format>MM-dd-HH-mm-ss</maven.build.timestamp.format>
 
-        <nosqldriver.version>5.3.4</nosqldriver.version>
+        <nosqldriver.version>5.4.9</nosqldriver.version>
 
         <spring.springframework.version>5.3.20</spring.springframework.version>
         <spring.data.version>2.7.0</spring.data.version>

--- a/src/main/java/com/oracle/nosql/spring/data/core/mapping/NosqlTable.java
+++ b/src/main/java/com/oracle/nosql/spring/data/core/mapping/NosqlTable.java
@@ -136,13 +136,11 @@ public @interface NosqlTable {
      * {@link com.oracle.nosql.spring.data.Constants#NOTSET_TABLE_TTL} is used,
      * which means no table level TTL. This is applicable only when
      * {@link #autoCreateTable} is set to true.
-     * <p>
      *
      * @since 1.5.0
      * @see oracle.nosql.driver.TimeToLive
-     * @see <a href="https://docs.oracle.com/en/database/other-databases/nosql-database/22.3/java-driver-table/using-time-live.html#GUID-A768A8F9-309A-4018-8CC3-D2D6B8793C59">Using TTL</a>
+     * @see <a href="https://docs.oracle.com/en/database/other-databases/nosql-database/22.3/java-driver-table/using-time-live.html">Using TTL</a>
      */
-
     int ttl() default Constants.NOTSET_TABLE_TTL;
 
     enum TtlUnit {

--- a/src/main/java/com/oracle/nosql/spring/data/repository/support/NosqlEntityInformation.java
+++ b/src/main/java/com/oracle/nosql/spring/data/repository/support/NosqlEntityInformation.java
@@ -355,7 +355,11 @@ public class NosqlEntityInformation <T, ID> extends
     }
 
     public void setConsistency(String consistency) {
-        this.consistency = Consistency.valueOf(consistency);
+        if (Consistency.ABSOLUTE.getType().toString().equalsIgnoreCase(consistency)) {
+            this.consistency = Consistency.ABSOLUTE;
+        } else {
+            this.consistency = Consistency.EVENTUAL;
+        }
     }
 
     public Durability getDurability() {

--- a/src/main/java/com/oracle/nosql/spring/data/repository/support/SimpleNosqlRepository.java
+++ b/src/main/java/com/oracle/nosql/spring/data/repository/support/SimpleNosqlRepository.java
@@ -236,7 +236,7 @@ public class SimpleNosqlRepository <T, ID extends Serializable>
      */
     @Override
     public String getConsistency() {
-        return entityInformation.getConsistency().name();
+        return entityInformation.getConsistency().getType().name();
     }
 
     /**

--- a/src/main/java/com/oracle/nosql/spring/data/repository/support/SimpleReactiveNosqlRepository.java
+++ b/src/main/java/com/oracle/nosql/spring/data/repository/support/SimpleReactiveNosqlRepository.java
@@ -217,7 +217,7 @@ public class SimpleReactiveNosqlRepository <T, ID extends Serializable>
      */
     @Override
     public String getConsistency() {
-        return entityInformation.getConsistency().name();
+        return entityInformation.getConsistency().getType().name();
     }
 
     /**


### PR DESCRIPTION
 - updated NoSQL Java SDK version to 5.4.9: updated the way Consistency is used.
 - updated CHANGELOG.md.
 - fix javadoc error and link