### PR TITLE
Dependencies upgrade

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,7 +3,24 @@ All notable changes to this project will be documented in this file.
 
 The format is based on [Keep a Changelog](http://keepachangelog.com/).
 
-## [1.7.0]
+## [2.0.0] 
+ - Upgrade dependencies:
+  - Spring framework: 5.3.27 to 6.0.11
+  - Spring Data: 2.7.0 to 3.1.2
+  - Apache commons-lang3: 3.12.0 to 3.13.0
+  - Reactor core: 3.4.19 to 3.5.8
+  - Spring boot starter: 2.7.0 to 3.1.2
+  - Slf4j: 1.7.36 to 2.0.7
+  - maven-compiler-plugin: 2.3.2 to 3.11.0
+  - maven-javadoc-plugin: 3.4.0 to 3.5.0
+  - maven-source-plugin: 3.2.1 to 3.3.0
+  - maven-checkstyle-plugin: 2.17 to 3.0.0
+  - maven-help-plugin: 3.1.0 to 3.4.0
+  - maven-jar-plugin: 3.2.0 to 3.3.0
+  - exec-maven-plugin: 3.0.0 to 3.1.0
+  - maven-surefire-plugin: 3.0.0-M5 to 3.1.2
+
+## [1.7.1]
 ### Added
 - Added the checks to verify entity definition matches with corresponding 
   table in the database during table creation.

--- a/config/checkstyle.xml
+++ b/config/checkstyle.xml
@@ -160,8 +160,7 @@ page at http://checkstyle.sourceforge.net/config.html -->
       -->
 
       <property name="ignorePattern"
-                value="${com.puppycrawl.tools.checkstyle.checks.sizes.LineLength.ignorePattern}"
-                default="^(package .*;\s*)|(import .*;\s*)|(.*https?://.*)$"/>
+                value="^(package .*;\s*)|(import .*;\s*)|(.*https?://.*)$"/>
     </module>
 
     <module name="RightCurly">

--- a/pom.xml
+++ b/pom.xml
@@ -6,7 +6,7 @@
 
     <groupId>com.oracle.nosql.sdk</groupId>
     <artifactId>spring-data-oracle-nosql</artifactId>
-    <version>1.7.1</version>
+    <version>2.0.0</version>
 
     <name>Oracle NoSQL Database SDK for Spring Data</name>
     <description>Oracle NoSQL Database SDK for Spring Data</description>
@@ -47,15 +47,15 @@
 
         <nosqldriver.version>5.4.11</nosqldriver.version>
 
-        <spring.springframework.version>5.3.27</spring.springframework.version>
-        <spring.data.version>2.7.0</spring.data.version>
-        <org.apache.commons.commons-lang3.version>3.12.0</org.apache.commons.commons-lang3.version>
-        <reactor.core.version>3.4.19</reactor.core.version>
+        <spring.springframework.version>6.0.11</spring.springframework.version>
+        <spring.data.version>3.1.2</spring.data.version>
+        <org.apache.commons.commons-lang3.version>3.13.0</org.apache.commons.commons-lang3.version>
+        <reactor.core.version>3.5.8</reactor.core.version>
 
-        <spring.boot.starter.test.version>2.7.0</spring.boot.starter.test.version>
+        <spring.boot.starter.test.version>3.1.2</spring.boot.starter.test.version>
         <junit.junit.version>4.13.2</junit.junit.version>
-        <project.reactor.test.version>3.4.19</project.reactor.test.version>
-        <slf4j.version>1.7.36</slf4j.version>
+        <project.reactor.test.version>3.5.8</project.reactor.test.version>
+        <slf4j.version>2.0.7</slf4j.version>
     </properties>
 
     <dependencies>
@@ -242,7 +242,7 @@
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-compiler-plugin</artifactId>
-                <version>2.3.2</version>
+                <version>3.11.0</version>
                 <configuration>
                     <compilerArgument>-Xlint</compilerArgument>
                 </configuration>
@@ -251,7 +251,7 @@
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-javadoc-plugin</artifactId>
-                <version>3.4.0</version>
+                <version>3.5.0</version>
                 <configuration>
                     <show>protected</show>
                     <failOnError>false</failOnError>
@@ -276,7 +276,7 @@
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-source-plugin</artifactId>
-                <version>2.2.1</version>
+                <version>3.3.0</version>
                 <executions>
                     <execution>
                         <id>attach-sources</id>
@@ -291,7 +291,7 @@
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-checkstyle-plugin</artifactId>
-                <version>2.17</version>
+                <version>3.0.0</version>
                 <executions>
                     <execution>
                         <id>validate</id>
@@ -319,7 +319,7 @@
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-help-plugin</artifactId>
-                <version>3.1.0</version>
+                <version>3.4.0</version>
                 <executions>
                     <execution>
                         <id>show-profiles</id>
@@ -334,7 +334,7 @@
             <!-- include info in MANIFEST.MF file -->
             <plugin>
                 <artifactId>maven-jar-plugin</artifactId>
-                <version>3.2.0</version>
+                <version>3.3.0</version>
                 <configuration>
                     <archive>
                         <manifest>
@@ -382,7 +382,7 @@
             <plugin>
                 <groupId>org.codehaus.mojo</groupId>
                 <artifactId>exec-maven-plugin</artifactId>
-                <version>3.0.0</version>
+                <version>3.1.0</version>
                 <executions>
                     <execution>
                         <id>add license files to runtime jar</id>
@@ -439,7 +439,7 @@
             <plugin>
                 <!-- test plugin -->
                 <artifactId>maven-surefire-plugin</artifactId>
-                <version>3.0.0-M5</version>
+                <version>3.1.2</version>
                 <configuration>
                     <!-- uncomment below to write stdout to files
                          in target/surefire-reports -->

--- a/src/main/java/com/oracle/nosql/spring/data/repository/NosqlRepository.java
+++ b/src/main/java/com/oracle/nosql/spring/data/repository/NosqlRepository.java
@@ -17,12 +17,14 @@ import com.oracle.nosql.spring.data.core.mapping.NosqlTable;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
 import org.springframework.data.domain.Sort;
+import org.springframework.data.repository.CrudRepository;
 import org.springframework.data.repository.NoRepositoryBean;
 import org.springframework.data.repository.PagingAndSortingRepository;
 
 @NoRepositoryBean
 public interface NosqlRepository<T, ID extends Serializable> extends
-    PagingAndSortingRepository<T, ID> {
+    PagingAndSortingRepository<T, ID>,
+    CrudRepository<T, ID> {
 
     /*
      * (non-Javadoc)

--- a/src/main/java/com/oracle/nosql/spring/data/repository/ReactiveNosqlRepository.java
+++ b/src/main/java/com/oracle/nosql/spring/data/repository/ReactiveNosqlRepository.java
@@ -11,7 +11,6 @@ import oracle.nosql.driver.Durability;
 
 import com.oracle.nosql.spring.data.core.mapping.NosqlTable;
 
-import org.springframework.data.repository.CrudRepository;
 import org.springframework.data.repository.NoRepositoryBean;
 import org.springframework.data.repository.reactive.ReactiveCrudRepository;
 import org.springframework.data.repository.reactive.ReactiveSortingRepository;

--- a/src/main/java/com/oracle/nosql/spring/data/repository/ReactiveNosqlRepository.java
+++ b/src/main/java/com/oracle/nosql/spring/data/repository/ReactiveNosqlRepository.java
@@ -11,12 +11,15 @@ import oracle.nosql.driver.Durability;
 
 import com.oracle.nosql.spring.data.core.mapping.NosqlTable;
 
+import org.springframework.data.repository.CrudRepository;
 import org.springframework.data.repository.NoRepositoryBean;
+import org.springframework.data.repository.reactive.ReactiveCrudRepository;
 import org.springframework.data.repository.reactive.ReactiveSortingRepository;
 
 @NoRepositoryBean
-public interface ReactiveNosqlRepository <T, K>
-    extends ReactiveSortingRepository<T, K> {
+public interface ReactiveNosqlRepository <T, K> extends
+    ReactiveSortingRepository<T, K>,
+    ReactiveCrudRepository<T, K> {
 
     /**
      * Returns the configured request timeout value, in milliseconds, or 0 if


### PR DESCRIPTION
 - Spring framework: 5.3.27 to 6.0.11
 - Spring Data: 2.7.0 to 3.1.2
 - Apache commons-lang3: 3.12.0 to 3.13.0
 - Reactor core: 3.4.19 to 3.5.8
 - Spring boot starter: 2.7.0 to 3.1.2
 - Slf4j: 1.7.36 to 2.0.7
 - maven-compiler-plugin: 2.3.2 to 3.11.0
 - maven-javadoc-plugin: 3.4.0 to 3.5.0
 - maven-source-plugin: 3.2.1 to 3.3.0
 - maven-checkstyle-plugin: 2.17 to 3.0.0
 - maven-help-plugin: 3.1.0 to 3.4.0
 - maven-jar-plugin: 3.2.0 to 3.3.0
 - exec-maven-plugin: 3.0.0 to 3.1.0
 - maven-surefire-plugin: 3.0.0-M5 to 3.1.2