### PR TITLE
Upgrade NoSQL SDK to 5.4.12 plus fixes.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,8 +3,13 @@ All notable changes to this project will be documented in this file.
 
 The format is based on [Keep a Changelog](http://keepachangelog.com/).
 
-## [2.0.0] 
- - Upgrade dependencies:
+## [Unreleased]
+### Changed
+- Upgrade NoSQL Java SDK dependency to version 5.4.12.
+
+## [2.0.0] - 2023-08-29
+### Changed
+- Upgrade dependencies:
   - Spring framework: 5.3.27 to 6.0.11
   - Spring Data: 2.7.0 to 3.1.2
   - Apache commons-lang3: 3.12.0 to 3.13.0
@@ -13,14 +18,14 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/).
   - Slf4j: 1.7.36 to 2.0.7
   - maven-compiler-plugin: 2.3.2 to 3.11.0
   - maven-javadoc-plugin: 3.4.0 to 3.5.0
-  - maven-source-plugin: 3.2.1 to 3.3.0
   - maven-checkstyle-plugin: 2.17 to 3.0.0
   - maven-help-plugin: 3.1.0 to 3.4.0
   - maven-jar-plugin: 3.2.0 to 3.3.0
   - exec-maven-plugin: 3.0.0 to 3.1.0
   - maven-surefire-plugin: 3.0.0-M5 to 3.1.2
+- Requirements moved to JDK 17+.
 
-## [1.7.1]
+## [1.7.1] - 2023-07-26
 ### Added
 - Added the checks to verify entity definition matches with corresponding 
   table in the database during table creation.
@@ -28,14 +33,14 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/).
 ### Changed
 - Upgrade NoSQL Java SDK dependency to version 5.4.11.
 
-## [1.6.0]
+## [1.6.0] - 2023-05-05
 ### Added
 - Added support for composite primary keys.
 
 ### Changed
 - Upgrade NoSQL Java SDK dependency to version 5.4.10.
 
-## [1.5.0]
+## [1.5.0] - 2023-03-06
 ### Added
 - Added support for java.util.Map and similar types as mapping types.
 - Added support for evaluating SpEl expressions on NosqlTable.tableName annotation.
@@ -44,13 +49,13 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/).
 ### Changed
 - Updated documentation links.
 
-## [1.4.1]
+## [1.4.1] - 2022-07-27
 ### Added
 - Add a way to return the library version using NosqlDbFactory.getLibraryVersion().
 - Add NoSQL-SpringSDK/version as extension to http user agent.
 - Added LICENSE.txt and THIRD_PARTY_LICENSES.txt to runtime jar file and LICENSE.txt to sources and javadoc jars.
 
-## [1.4.0]
+## [1.4.0] - 2022-06-27
 ### Added
 - On-premise only, added support for setting durability option on writes.
 - Add durability setter/getter on NosqlRepository and ReactiveNosqlRepository interfaces and implementing classes.
@@ -66,7 +71,7 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/).
 - Update javadoc related to default table limits.
 - Update library dependency versions.
 
-## [1.3.0]
+## [1.3.0] - 2022-04-19
 ### Changed
 - Updated library dependency versions and updated THIRD_PARTY_LICENSES.txt 
 and THIRD_PARTY_LICENSES_DEV.txt.

--- a/README.md
+++ b/README.md
@@ -10,7 +10,7 @@ cluster or to
 
 ## Requirements
 
-Java versions 8 and higher are supported.
+Java versions 17 and higher are supported.
 
 ## Installation
 
@@ -28,7 +28,7 @@ project. The version changes with each release.
 <dependency>
   <groupId>com.oracle.nosql.sdk</groupId>
   <artifactId>spring-data-oracle-nosql</artifactId>
-  <version>1.6.0</version>
+  <version>2.0.0</version>
 </dependency>
 ```
 
@@ -76,7 +76,7 @@ See [CHANGELOG](./CHANGELOG.md) for changes in each release.
     <dependency>
       <groupId>org.springframework.boot</groupId>
       <artifactId>spring-boot-starter</artifactId>
-      <version>2.7.0</version>
+      <version>3.1.2</version>
     </dependency>
     ```
 

--- a/pom.xml
+++ b/pom.xml
@@ -39,13 +39,13 @@
     </scm>
 
     <properties>
-        <maven.compiler.source>1.8</maven.compiler.source>
-        <maven.compiler.target>1.8</maven.compiler.target>
+        <maven.compiler.source>17</maven.compiler.source>
+        <maven.compiler.target>17</maven.compiler.target>
 
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
         <maven.build.timestamp.format>MM-dd-HH-mm-ss</maven.build.timestamp.format>
 
-        <nosqldriver.version>5.4.11</nosqldriver.version>
+        <nosqldriver.version>5.4.12</nosqldriver.version>
 
         <spring.springframework.version>6.0.11</spring.springframework.version>
         <spring.data.version>3.1.2</spring.data.version>
@@ -245,6 +245,9 @@
                 <version>3.11.0</version>
                 <configuration>
                     <compilerArgument>-Xlint</compilerArgument>
+                    <compilerArgs>
+                        <arg>-parameters</arg>
+                    </compilerArgs>
                 </configuration>
             </plugin>
 


### PR DESCRIPTION
Upgrade NoSQL SDK to 5.4.12
Changed requirements to JDK 17+ due to Spring upgrade.
Fix CHANGELOG.md and README.md.
Fixed Spring runtime warnings.