### PR TITLE
Remove prepared statement from cache if error

### DIFF
--- a/src/main/java/com/oracle/nosql/spring/data/config/NosqlDbConfig.java
+++ b/src/main/java/com/oracle/nosql/spring/data/config/NosqlDbConfig.java
@@ -136,14 +136,14 @@ public class NosqlDbConfig {
     }
 
     /**
-     * Sets the capacity of the prepared query cache. By default this is set
+     * Sets the capacity of the prepared query cache. By default, this is set
      * to {@link Constants#DEFAULT_QUERY_CACHE_CAPACITY}. The prepared query
      * cache is controlled by both {@link #setQueryCacheCapacity(int)} and
      * {@link #setQueryCacheLifetime(int)}. If capacity is 0 then entries are
      * only ever removed because they expire. If lifetime is 0 then entries are
      * only ever removed because the cache has reached capacity.
      */
-    NosqlDbConfig setQueryCacheCapacity(int capacity) {
+    public NosqlDbConfig setQueryCacheCapacity(int capacity) {
         queryCacheCapacity = capacity;
         return this;
     }
@@ -159,14 +159,14 @@ public class NosqlDbConfig {
 
     /**
      * Sets the lifetime of the prepared query cache in milliseconds. By
-     * default this is set to {@link Constants#DEFAULT_QUERY_CACHE_LIFETIME_MS}.
+     * default, this is set to {@link Constants#DEFAULT_QUERY_CACHE_LIFETIME_MS}.
      * The prepared query cache is controlled by both
      * {@link #setQueryCacheCapacity(int)} and
      * {@link #setQueryCacheLifetime(int)}. If capacity is 0 then entries are
      * only ever removed because they expire. If lifetime is 0 then entries are
      * only ever removed because the cache has reached capacity.
      */
-    NosqlDbConfig setQueryCacheLifetime(int lifetime) {
+    public NosqlDbConfig setQueryCacheLifetime(int lifetime) {
         queryCacheLifetime = lifetime;
         return this;
     }

--- a/src/test/java/com/oracle/nosql/spring/data/test/TestApplication.java
+++ b/src/test/java/com/oracle/nosql/spring/data/test/TestApplication.java
@@ -25,6 +25,7 @@ import com.oracle.nosql.spring.data.NosqlDbFactory;
 import com.oracle.nosql.spring.data.core.NosqlOperations;
 import com.oracle.nosql.spring.data.core.NosqlTemplate;
 import com.oracle.nosql.spring.data.core.mapping.NosqlCapacityMode;
+import com.oracle.nosql.spring.data.repository.support.NosqlEntityInformation;
 import com.oracle.nosql.spring.data.test.app.Address;
 import com.oracle.nosql.spring.data.test.app.AppConfig;
 import com.oracle.nosql.spring.data.test.app.Customer;
@@ -673,5 +674,37 @@ public class TestApplication {
                 System.out.println("      " + Arrays.toString(arr));
             }
         }
+    }
+
+    @Test
+    public void testPrepStmtCacheRemove() throws ClassNotFoundException {
+        // todo: add invalidate prepared statements cache
+        // repo.invalidateCache();
+
+        // Use query, which will cache the prepared statement
+        List<Customer> customerList = repo.findByLastName("Smith");
+        Assert.assertEquals(0, customerList.size());
+
+        // Drop table
+        NosqlTemplate template = NosqlTemplate.create(AppConfig.nosqlDBConfig);
+
+        template.runTableRequest(
+            "DROP TABLE Customer");
+
+        try {
+            customerList = repo.findByLastName("Smith");
+            Assert.assertEquals(0, customerList.size());
+            Assert.fail("Should throw a 'Table not found' exception");
+        } catch (Exception e) {
+            Assert.assertEquals("Table not found: customer",
+                e.getCause().getMessage());
+        }
+
+        NosqlEntityInformation<Customer, ?> customerEntInfo =
+            template.getNosqlEntityInformation(Customer.class);
+        template.createTableIfNotExists(customerEntInfo);
+
+        customerList = repo.findByLastName("Smith");
+        Assert.assertEquals(0, customerList.size());
     }
 }


### PR DESCRIPTION
Remove prepared statement from cache if error is thrown when reading the results.
Fix public access to NosqlDbConfig.setQueryCacheLifetime(int). 
Add info log entry for creating cache (with params) and when query is removed from cache.
Add test to check error is thrown when table is dropped.