### PR TITLE
Update dependecy versions move to 2.1.0 release

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,10 +3,16 @@ All notable changes to this project will be documented in this file.
 
 The format is based on [Keep a Changelog](http://keepachangelog.com/).
 
-## [Unreleased]
+## [2.1.0] - 2024-09-19
 ### Changed
 - Update copyrights to 2024
-- Upgrade NoSQL Java SDK dependency to version 5.4.12.
+- Upgrade dependency to latest versions:
+  - NoSQL Java SDK dependency to version 5.4.15
+  - Spring Framework to version 6.1.13
+  - Spring Data to version 3.3.4
+  - Apache Commons lang3 to version3.17.0
+  - Project Reactor to version 3.6.10
+  - Slf4j to version 2.0.16
 
 ## [2.0.0] - 2023-08-29
 ### Changed

--- a/README.md
+++ b/README.md
@@ -28,7 +28,7 @@ project. The version changes with each release.
 <dependency>
   <groupId>com.oracle.nosql.sdk</groupId>
   <artifactId>spring-data-oracle-nosql</artifactId>
-  <version>2.0.0</version>
+  <version>2.1.0</version>
 </dependency>
 ```
 
@@ -76,7 +76,7 @@ See [CHANGELOG](./CHANGELOG.md) for changes in each release.
     <dependency>
       <groupId>org.springframework.boot</groupId>
       <artifactId>spring-boot-starter</artifactId>
-      <version>3.1.2</version>
+      <version>3.3.4</version>
     </dependency>
     ```
 

--- a/pom.xml
+++ b/pom.xml
@@ -6,7 +6,7 @@
 
     <groupId>com.oracle.nosql.sdk</groupId>
     <artifactId>spring-data-oracle-nosql</artifactId>
-    <version>2.0.0</version>
+    <version>2.1.0</version>
 
     <name>Oracle NoSQL Database SDK for Spring Data</name>
     <description>Oracle NoSQL Database SDK for Spring Data</description>
@@ -48,7 +48,7 @@
         <nosqldriver.version>5.4.15</nosqldriver.version>
 
         <spring.springframework.version>6.1.13</spring.springframework.version>
-        <spring.data.version>3.3.3</spring.data.version>
+        <spring.data.version>3.3.4</spring.data.version>
         <org.apache.commons.commons-lang3.version>3.17.0</org.apache.commons.commons-lang3.version>
         <reactor.core.version>3.6.10</reactor.core.version>
 

--- a/pom.xml
+++ b/pom.xml
@@ -45,17 +45,17 @@
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
         <maven.build.timestamp.format>MM-dd-HH-mm-ss</maven.build.timestamp.format>
 
-        <nosqldriver.version>5.4.13</nosqldriver.version>
+        <nosqldriver.version>5.4.15</nosqldriver.version>
 
-        <spring.springframework.version>6.0.16</spring.springframework.version>
-        <spring.data.version>3.1.2</spring.data.version>
-        <org.apache.commons.commons-lang3.version>3.13.0</org.apache.commons.commons-lang3.version>
-        <reactor.core.version>3.5.8</reactor.core.version>
+        <spring.springframework.version>6.1.13</spring.springframework.version>
+        <spring.data.version>3.3.3</spring.data.version>
+        <org.apache.commons.commons-lang3.version>3.17.0</org.apache.commons.commons-lang3.version>
+        <reactor.core.version>3.6.10</reactor.core.version>
 
-        <spring.boot.starter.test.version>3.1.2</spring.boot.starter.test.version>
+        <spring.boot.starter.test.version>3.3.4</spring.boot.starter.test.version>
         <junit.junit.version>4.13.2</junit.junit.version>
-        <project.reactor.test.version>3.5.8</project.reactor.test.version>
-        <slf4j.version>2.0.7</slf4j.version>
+        <project.reactor.test.version>3.6.10</project.reactor.test.version>
+        <slf4j.version>2.0.16</slf4j.version>
     </properties>
 
     <dependencies>


### PR DESCRIPTION
Updated dependencies to the latest versions.
Prepare for a new 2.1.0 release.