### PR TITLE
clear prepared statement cache

### DIFF
--- a/src/main/java/com/oracle/nosql/spring/data/core/NosqlOperations.java
+++ b/src/main/java/com/oracle/nosql/spring/data/core/NosqlOperations.java
@@ -24,6 +24,12 @@ public interface NosqlOperations {
      */
     boolean createTableIfNotExists(NosqlEntityInformation<?, ?> entityInformation);
 
+
+    /**
+     * Clears the cache of prepared statements for this repository.
+     */
+    void clearPreparedStatementsCache();
+
     /**
      * Drops the given table, information about all saved entities is
      * removed.

--- a/src/main/java/com/oracle/nosql/spring/data/core/NosqlTemplate.java
+++ b/src/main/java/com/oracle/nosql/spring/data/core/NosqlTemplate.java
@@ -258,6 +258,7 @@ public class NosqlTemplate
         TableRequest tableReq = new TableRequest().setStatement(sql);
 
         TableResult tableRes = doTableRequest(null, tableReq);
+        psCache.clear();
 
         return tableRes.getTableState() == TableResult.State.DROPPED ||
             tableRes.getTableState() == TableResult.State.DROPPING;

--- a/src/main/java/com/oracle/nosql/spring/data/core/NosqlTemplateBase.java
+++ b/src/main/java/com/oracle/nosql/spring/data/core/NosqlTemplateBase.java
@@ -89,7 +89,7 @@ public abstract class NosqlTemplateBase
         this.nosqlDbFactory = nosqlDbFactory;
         nosqlClient = nosqlDbFactory.getNosqlClient();
         this.mappingNosqlConverter = mappingNosqlConverter;
-        LOG.info("Create cache for prepared statements with capacity " +
+        LOG.debug("Create cache for prepared statements with capacity " +
             nosqlDbFactory.getQueryCacheCapacity() + " items and lifetime " +
             nosqlDbFactory.getQueryCacheLifetime() + " ms.");
         psCache = new LruCache<>(nosqlDbFactory.getQueryCacheCapacity(),
@@ -624,5 +624,12 @@ public abstract class NosqlTemplateBase
                     TEMPLATE_GENERATED_UUID : TEMPLATE_GENERATED_ALWAYS;
         }
         return "";
+    }
+
+    /**
+     * Clears the cache of prepared statements.
+     */
+    public void clearPreparedStatementsCache() {
+        psCache.clear();
     }
 }

--- a/src/main/java/com/oracle/nosql/spring/data/core/ReactiveNosqlOperations.java
+++ b/src/main/java/com/oracle/nosql/spring/data/core/ReactiveNosqlOperations.java
@@ -43,6 +43,12 @@ public interface ReactiveNosqlOperations {
      */
     Mono<Boolean> dropTableIfExists(String tableName);
 
+    /**
+     * Clears the cache of prepared statements.
+     */
+    void clearPreparedStatementsCache();
+
+
     <T, ID> Flux<T> findAll(NosqlEntityInformation<T, ID> entityInformation);
 
     <T> Flux<T> findAll(Class<T> entityClass);

--- a/src/main/java/com/oracle/nosql/spring/data/core/ReactiveNosqlTemplate.java
+++ b/src/main/java/com/oracle/nosql/spring/data/core/ReactiveNosqlTemplate.java
@@ -107,6 +107,12 @@ public class ReactiveNosqlTemplate
     }
 
     @Override
+    public void clearPreparedStatementsCache() {
+        super.clearPreparedStatementsCache();
+    }
+
+
+    @Override
     public <T, ID> Flux<T> findAll(
         NosqlEntityInformation<T, ID> entityInformation) {
         Assert.notNull(entityInformation, "EntityInformation should " +

--- a/src/main/java/com/oracle/nosql/spring/data/repository/NosqlRepository.java
+++ b/src/main/java/com/oracle/nosql/spring/data/repository/NosqlRepository.java
@@ -164,4 +164,9 @@ public interface NosqlRepository<T, ID extends Serializable> extends
      * Note: This applies to On-Prem installations only.
      */
     void setDurability(String durability);
+
+    /**
+     * Clears the prepared statements cache.
+     */
+    void clearPreparedStatementsCache();
 }

--- a/src/main/java/com/oracle/nosql/spring/data/repository/ReactiveNosqlRepository.java
+++ b/src/main/java/com/oracle/nosql/spring/data/repository/ReactiveNosqlRepository.java
@@ -63,4 +63,9 @@ public interface ReactiveNosqlRepository <T, K> extends
      * Note: This applies to On-Prem installations only.
      */
     void setDurability(String durability);
+
+    /**
+     * Clears the prepared statements cache.
+     */
+    void clearPreparedStatementsCache();
 }

--- a/src/main/java/com/oracle/nosql/spring/data/repository/support/SimpleNosqlRepository.java
+++ b/src/main/java/com/oracle/nosql/spring/data/repository/support/SimpleNosqlRepository.java
@@ -276,4 +276,12 @@ public class SimpleNosqlRepository <T, ID extends Serializable>
     public void setDurability(String durability) {
         entityInformation.setDurability(durability);
     }
+
+
+    /**
+     * @see NosqlRepository#clearPreparedStatementsCache()
+     */
+    public void clearPreparedStatementsCache() {
+        operation.clearPreparedStatementsCache();
+    }
 }

--- a/src/main/java/com/oracle/nosql/spring/data/repository/support/SimpleReactiveNosqlRepository.java
+++ b/src/main/java/com/oracle/nosql/spring/data/repository/support/SimpleReactiveNosqlRepository.java
@@ -251,4 +251,13 @@ public class SimpleReactiveNosqlRepository <T, ID extends Serializable>
     public void setDurability(String durability) {
         entityInformation.setDurability(durability);
     }
+
+
+    /**
+     * Clears the prepared statements cache.
+     */
+    @Override
+    public void clearPreparedStatementsCache() {
+        nosqlOperations.clearPreparedStatementsCache();
+    }
 }

--- a/src/test/java/com/oracle/nosql/spring/data/test/composite/MachineApp.java
+++ b/src/test/java/com/oracle/nosql/spring/data/test/composite/MachineApp.java
@@ -48,13 +48,16 @@ public class MachineApp {
     @BeforeClass
     public static void staticSetup() throws ClassNotFoundException {
         template = NosqlTemplate.create(AppConfig.nosqlDBConfig);
+        template.dropTableIfExists(Machine.class.getSimpleName());
+        template.createTableIfNotExists(template.
+            getNosqlEntityInformation(Machine.class));
     }
 
     @Before
     public void setup() {
-        template.dropTableIfExists(Machine.class.getSimpleName());
-        template.createTableIfNotExists(template.
-                getNosqlEntityInformation(Machine.class));
+        repo.clearPreparedStatementsCache();
+        repo.deleteAll();
+
         machineCache = new HashMap<>();
         List<IpAddress> routeAddress = new ArrayList<>();
         routeAddress.add(new IpAddress("127.0.0.1"));
@@ -77,12 +80,11 @@ public class MachineApp {
 
         //get total count of records
         assertEquals(16, repo.count());
-
     }
 
     @After
     public void teardown() {
-        template.dropTableIfExists(Machine.class.getSimpleName());
+        // do not drop table between tests
     }
 
     @Test

--- a/src/test/java/com/oracle/nosql/spring/data/test/composite/ReactiveMachineApp.java
+++ b/src/test/java/com/oracle/nosql/spring/data/test/composite/ReactiveMachineApp.java
@@ -46,13 +46,15 @@ public class ReactiveMachineApp {
     @BeforeClass
     public static void staticSetup() throws ClassNotFoundException {
         template = NosqlTemplate.create(AppConfig.nosqlDBConfig);
+        template.dropTableIfExists(Machine.class.getSimpleName());
+        template.createTableIfNotExists(template.
+            getNosqlEntityInformation(Machine.class));
     }
 
     @Before
     public void setup() {
-        template.dropTableIfExists(Machine.class.getSimpleName());
-        template.createTableIfNotExists(template.
-                getNosqlEntityInformation(Machine.class));
+        repo.clearPreparedStatementsCache();
+        repo.deleteAll();
         machineCache = new HashMap<>();
         List<IpAddress> routeAddress = new ArrayList<>();
         routeAddress.add(new IpAddress("127.0.0.1"));
@@ -78,7 +80,7 @@ public class ReactiveMachineApp {
 
     @After
     public void teardown() {
-        template.dropTableIfExists(Machine.class.getSimpleName());
+        // don't drop table between tests
     }
 
     @Test


### PR DESCRIPTION
Add new clearPreparedStatementsCache() method on NosqlRepository, ReactiveNosqlRepository and NosqlTemplateBase.

Modified MachineApp and ReactiveMachineApp tests to delete all rows instead of dropping the table after each test.